### PR TITLE
Issue #32 account preferences

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ executable(
     'src/API/Account.vala',
     'src/API/Relationship.vala',
     'src/API/Mention.vala',
+    'src/API/Preferences.vala',
     'src/API/Tag.vala',
     'src/API/Status.vala',
     'src/API/StatusVisibility.vala',

--- a/src/API/Preferences.vala
+++ b/src/API/Preferences.vala
@@ -4,13 +4,13 @@
 
 public class Olifant.API.Preferences {
 
-    public string posting_default_visibility;
-    public bool posting_default_sensitive;
-    public string? posting_default_language;
-    public string reading_expand_media;
-    public bool reading_expand_spoilers;
+    public string posting_default_visibility {get; set;}
+    public bool posting_default_sensitive {get; set;}
+    public string? posting_default_language {get; set; default = null;}
+    public string reading_expand_media {get; set;}
+    public bool reading_expand_spoilers {get; set;}
 
-    public Preferences () {/* TODO? */}
+    public Preferences () {}
 
     public static Preferences parse (Json.Object obj) {
         var prefs = new Preferences ();
@@ -48,14 +48,3 @@ public class Olifant.API.Preferences {
         return builder.get_root ();
     }
 }
-
-/* TODO: put this where it goes
-var msg = new Soup.Message ("GET", "%s/api/v1/preferences".printf (accounts.formal.instance));
-network.inject (msg, Network.INJECT_TOKEN);
-network.queue (msg, (sess, mess) => {
-    var root = network.parse (mess);
-    preferences = API.Preferences.parse (root);
-}, (status, reason) => {
-    network.on_show_error (status, reason);
-});
-*/

--- a/src/API/Preferences.vala
+++ b/src/API/Preferences.vala
@@ -1,0 +1,61 @@
+/**
+ * This is the class for translating Mastodon API Preferences JSON objects.
+ */
+
+public class Olifant.API.Preferences {
+
+    public string posting_default_visibility;
+    public bool posting_default_sensitive;
+    public string? posting_default_language;
+    public string reading_expand_media;
+    public bool reading_expand_spoilers;
+
+    public Preferences () {/* TODO? */}
+
+    public static Preferences parse (Json.Object obj) {
+        var prefs = new Preferences ();
+
+        prefs.posting_default_visibility = obj.get_string_member ("posting:default:visibility");
+        prefs.posting_default_sensitive = obj.get_boolean_member ("posting:default:sensitive");
+        prefs.reading_expand_media = obj.get_string_member ("reading:expand:media");
+        prefs.reading_expand_spoilers = obj.get_boolean_member ("reading:expand:spoilers");
+
+        if (obj.has_member ("posting:default:language"))
+            prefs.posting_default_language = obj.get_string_member ("posting:default:language");
+
+        return prefs;
+    }
+
+    public Json.Node? serialize () {
+        var builder = new Json.Builder ();
+        builder.begin_object ();
+
+        builder.set_member_name ("posting:default:visibility");
+        builder.add_string_value (posting_default_visibility);
+        builder.set_member_name ("posting:default:sensitive");
+        builder.add_boolean_value (posting_default_sensitive);
+        builder.set_member_name ("reading:expand:media");
+        builder.add_string_value (reading_expand_media);
+        builder.set_member_name ("reading:expand:spoilers");
+        builder.add_boolean_value (reading_expand_spoilers);
+
+        if (posting_default_language != null) {
+            builder.set_member_name ("posting:default:language");
+            builder.add_string_value (posting_default_language);
+        }
+
+        builder.end_object ();
+        return builder.get_root ();
+    }
+}
+
+/* TODO: put this where it goes
+var msg = new Soup.Message ("GET", "%s/api/v1/preferences".printf (accounts.formal.instance));
+network.inject (msg, Network.INJECT_TOKEN);
+network.queue (msg, (sess, mess) => {
+    var root = network.parse (mess);
+    preferences = API.Preferences.parse (root);
+}, (status, reason) => {
+    network.on_show_error (status, reason);
+});
+*/

--- a/src/Accounts.vala
+++ b/src/Accounts.vala
@@ -39,6 +39,18 @@ public class Olifant.Accounts : Object {
                 currentInstance = API.Instance.parse (root);
             },
             network.on_show_error);
+
+        if (accounts.formal.preferences == null) {
+            info ("Getting preferences from %s", accounts.formal.instance);
+            msg = new Soup.Message ("GET", "%s/api/v1/preferences".printf (accounts.formal.instance));
+            network.inject (msg, Network.INJECT_TOKEN);
+            network.queue (msg, (sess, mess) => {
+                var root = network.parse (mess);
+                accounts.formal.preferences = API.Preferences.parse (root);
+                accounts.save ();
+            },
+            network.on_show_error);
+        }
     }
 
     public void add (InstanceAccount account) {

--- a/src/Dialogs/Compose.vala
+++ b/src/Dialogs/Compose.vala
@@ -31,6 +31,8 @@ public class Olifant.Dialogs.Compose : Dialog {
         replying_to = _replying_to;
         redrafting = _redrafting;
 
+        if (accounts.formal.preferences != null && accounts.formal.preferences.posting_default_visibility != "public")
+            visibility_opt = API.StatusVisibility.from_string (accounts.formal.preferences.posting_default_visibility);
         if (replying_to != null)
             visibility_opt = replying_to.visibility;
         if (redrafting != null)

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -20,6 +20,7 @@ public class Olifant.Dialogs.NewAccount : Dialog {
     private string? token;
     private string? username;
     private int64? instance_status_char_limit;
+    private string? posting_default_visibility;
 
     private const int64 DEFAULT_INSTANCE_STATUS_CHAR_LIMIT = 500;
 
@@ -199,13 +200,25 @@ public class Olifant.Dialogs.NewAccount : Dialog {
         network.queue (message, (sess, msg) => {
                 var root = network.parse (msg);
                 username = root.get_string_member ("username");
-                add_account ();
-                window.show ();
-                window.present ();
-                destroy ();
+                get_posting_default_visibility();
             }, (status, reason) => {
                 network.on_show_error (status, reason);
             });
+    }
+
+    private void get_posting_default_visibility () {
+        var msg = new Soup.Message ("GET", "%s/api/v1/preferences".printf (accounts.formal.instance));
+        network.inject (msg, Network.INJECT_TOKEN);
+        network.queue (msg, (sess, mess) => {
+            var root = network.parse (mess);
+            posting_default_visibility = root.get_string_member ("posting:default:visibility");
+            add_account ();
+            window.show ();
+            window.present ();
+            destroy ();
+        }, (status, reason) => {
+            network.on_show_error (status, reason);
+        });
     }
 
     private void add_account () {
@@ -216,6 +229,7 @@ public class Olifant.Dialogs.NewAccount : Dialog {
         account.client_secret = client_secret;
         account.token = token;
         account.status_char_limit = instance_status_char_limit;
+        account.posting_default_visibility = posting_default_visibility;
         accounts.add (account);
         app.activate ();
     }

--- a/src/InstanceAccount.vala
+++ b/src/InstanceAccount.vala
@@ -8,8 +8,9 @@ public class Olifant.InstanceAccount : Object {
     public string client_id {get; set;}
     public string client_secret {get; set;}
     public string token {get; set;}
-    public string? posting_default_visibility {get; set;}
     public int64? status_char_limit {get; set;}
+
+    public API.Preferences? preferences {get; set; default = null;}
 
     public int64 last_seen_notification {get; set; default = 0;}
     public bool has_unread_notifications {get; set; default = false;}
@@ -76,6 +77,11 @@ public class Olifant.InstanceAccount : Object {
             builder.add_int_value (status_char_limit);
         }
 
+        if (preferences != null) {
+            builder.set_member_name ("preferences");
+            builder.add_value (preferences.serialize ());
+        }
+
         builder.set_member_name ("cached_notifications");
         builder.begin_array ();
         cached_notifications.@foreach (notification => {
@@ -99,11 +105,14 @@ public class Olifant.InstanceAccount : Object {
         acc.token = obj.get_string_member ("token");
         acc.last_seen_notification = obj.get_int_member ("last_seen_notification");
         acc.has_unread_notifications = obj.get_boolean_member ("has_unread_notifications");
-        if (obj.has_member("status_char_limit")) {
+        if (obj.has_member ("status_char_limit")) {
             acc.status_char_limit = obj.get_int_member ("status_char_limit");
         } else {
             acc.status_char_limit = null;
         }
+
+        if (obj.has_member ("preferences"))
+            acc.preferences = API.Preferences.parse(obj.get_member ("preferences").get_object ());
 
         var notifications = obj.get_array_member ("cached_notifications");
         notifications.foreach_element ((arr, i, node) => {

--- a/src/InstanceAccount.vala
+++ b/src/InstanceAccount.vala
@@ -8,6 +8,7 @@ public class Olifant.InstanceAccount : Object {
     public string client_id {get; set;}
     public string client_secret {get; set;}
     public string token {get; set;}
+    public string? posting_default_visibility {get; set;}
     public int64? status_char_limit {get; set;}
 
     public int64 last_seen_notification {get; set; default = 0;}


### PR DESCRIPTION
### Summary
This pull request aims to resolve issue #32. Although it also lays the groundwork for expanding how Olifant handles the preferences API, it does not worry about any preference but default post visibility.

### Changes
The code added by this PR creates an `API.Preferences` object (and corresponding file) which is attached to a given account's `InstanceAccount` object. `InstanceAccount` serialization and parsing functions have been updated to reflect this. Preferences themselves are retrieved in `Dialogs.NewAccount` for newly-added accounts and in `Accounts` for existing accounts. All of this comes to fruition in `Dialogs.Compose` where the default visibility is now checked and applied.

### Notes
The `Accounts` code bears further explanation. When switching accounts, it checks whether that `InstanceAccount` has an `API.Preferences` object. If not, it retrieves the preferences, adds them to the object, then saves the accounts to ensure both the active session and any future sessions will have preferences. The reason it works like this is simply to ensure that the code in question is called at the beginning of every user session. This way, existing `InstanceAccount` objects can be updated without hassle and without interrupting the functionality of the program.

Ideally, this code would be removed in the future once substantially all existing users have had their information updated - say, a month or two after this update is released. If that is done, the null-ability of the `API.Preferences` member object in `InstanceAccount` should also be revoked, its serialization and parsing methods should remove their null checks, and the `visibility_opt` member of `Dialogs.Compose` should be updated similarly.