### PR TITLE
#33 Improve identifier capability

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ executable(
     'src/API/NotificationType.vala',
     'src/API/Attachment.vala',
     'src/API/Instance.vala',
+    'src/API/VersionInfo.vala',
     'src/Widgets/AlignedLabel.vala',
     'src/Widgets/RichLabel.vala',
     'src/Widgets/ImageToggleButton.vala',

--- a/src/API/Account.vala
+++ b/src/API/Account.vala
@@ -2,7 +2,7 @@ public class Olifant.API.Account {
 
     public abstract signal void updated ();
 
-    public int64 id;
+    public string id;
     public string username;
     public string acct;
     public string display_name;
@@ -17,12 +17,12 @@ public class Olifant.API.Account {
 
     public Relationship? rs;
 
-    public Account (int64 _id){
+    public Account (string _id){
         id = _id;
     }
 
     public static Account parse(Json.Object obj) {
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var account = new Account (id);
 
         account.username = obj.get_string_member ("username");
@@ -91,7 +91,7 @@ public class Olifant.API.Account {
     }
 
     public Soup.Message get_relationship (){
-        var url = "%s/api/v1/accounts/relationships?id=%lld".printf (accounts.formal.instance, id);
+        var url = "%s/api/v1/accounts/relationships?id=%s".printf (accounts.formal.instance, id);
         var msg = new Soup.Message("GET", url);
         msg.priority = Soup.MessagePriority.HIGH;
         network.queue (
@@ -111,7 +111,7 @@ public class Olifant.API.Account {
 
     public Soup.Message set_following (bool follow = true){
         var action = follow ? "follow" : "unfollow";
-        var url = "%s/api/v1/accounts/%lld/%s".printf (accounts.formal.instance, id, action);
+        var url = "%s/api/v1/accounts/%s/%s".printf (accounts.formal.instance, id, action);
         var msg = new Soup.Message("POST", url);
         msg.priority = Soup.MessagePriority.HIGH;
         network.queue (
@@ -131,7 +131,7 @@ public class Olifant.API.Account {
 
     public Soup.Message set_muted (bool mute = true){
         var action = mute ? "mute" : "unmute";
-        var url = "%s/api/v1/accounts/%lld/%s".printf (accounts.formal.instance, id, action);
+        var url = "%s/api/v1/accounts/%s/%s".printf (accounts.formal.instance, id, action);
         var msg = new Soup.Message("POST", url);
         msg.priority = Soup.MessagePriority.HIGH;
         network.queue (
@@ -151,7 +151,7 @@ public class Olifant.API.Account {
 
     public Soup.Message set_blocked (bool block = true){
         var action = block ? "block" : "unblock";
-        var url = "%s/api/v1/accounts/%lld/%s".printf (accounts.formal.instance, id, action);
+        var url = "%s/api/v1/accounts/%s/%s".printf (accounts.formal.instance, id, action);
         var msg = new Soup.Message("POST", url);
         msg.priority = Soup.MessagePriority.HIGH;
         network.queue (

--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -1,17 +1,17 @@
 public class Olifant.API.Attachment {
 
-    public int64 id;
+    public string id;
     public string type;
     public string url;
     public string preview_url;
     public string? description;
 
-    public Attachment (int64 _id) {
+    public Attachment (string _id) {
         id = _id;
     }
 
     public static Attachment parse (Json.Object obj) {
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var attachment = new Attachment (id);
 
         attachment.type = obj.get_string_member ("type");

--- a/src/API/Instance.vala
+++ b/src/API/Instance.vala
@@ -1,13 +1,18 @@
-public class Olifant.API.Instance{
+using Olifant.API;
 
+public class Olifant.API.Instance {
     public string uri;
     public string email;
-    public string version;
+    public VersionInfo version;
     public string[] languages;
     public string title;
 
-    public Instance (string _uri){
+    public Instance (owned string _uri){
         uri = _uri;
+    }
+
+    public bool is_mastodon_v3 () {
+        return this.version.major >= 3;
     }
 
     public static Instance parse(Json.Object obj) {
@@ -15,7 +20,7 @@ public class Olifant.API.Instance{
         var instance = new Instance (uri);
 
         instance.title = obj.get_string_member ("title");
-        instance.version = obj.get_string_member ("version");
+        instance.version = VersionInfo.parse (obj.get_string_member ("version"));
         instance.email = obj.get_string_member ("email");
 
         return instance;

--- a/src/API/Mention.vala
+++ b/src/API/Mention.vala
@@ -1,11 +1,11 @@
 public class Olifant.API.Mention : GLib.Object {
 
-    public int64 id;
+    public string id;
     public string username;
     public string acct;
     public string url;
 
-    public Mention (int64 _id){
+    public Mention (string _id){
         id = _id;
     }
 
@@ -17,7 +17,7 @@ public class Olifant.API.Mention : GLib.Object {
     }
 
     public static Mention parse (Json.Object obj){
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var mention = new Mention (id);
 
         mention.username = obj.get_string_member ("username");

--- a/src/API/Notification.vala
+++ b/src/API/Notification.vala
@@ -1,18 +1,18 @@
 public class Olifant.API.Notification {
 
-    public int64 id;
+    public string id;
     public NotificationType type;
     public string created_at;
 
     public Status? status;
     public Account? account;
 
-    public Notification (int64 _id) {
+    public Notification (string _id) {
         id = _id;
     }
 
     public static Notification parse (Json.Object obj) {
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var notification = new Notification (id);
 
         notification.type = NotificationType.from_string (obj.get_string_member ("type"));
@@ -50,7 +50,7 @@ public class Olifant.API.Notification {
     }
 
     public static Notification parse_follow_request (Json.Object obj) {
-        var notification = new Notification (-1);
+        var notification = new Notification ("");
         var account = Account.parse (obj);
 
         notification.type = NotificationType.FOLLOW_REQUEST;
@@ -69,7 +69,7 @@ public class Olifant.API.Notification {
         if (type == NotificationType.FOLLOW_REQUEST)
             return reject_follow_request ();
 
-        var url = "%s/api/v1/notifications/dismiss?id=%lld".printf (accounts.formal.instance, id);
+        var url = "%s/api/v1/notifications/dismiss?id=%s".printf (accounts.formal.instance, id);
         var msg = new Soup.Message ("POST", url);
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg);
@@ -77,7 +77,7 @@ public class Olifant.API.Notification {
     }
 
     public Soup.Message accept_follow_request () {
-        var url = "%s/api/v1/follow_requests/%lld/authorize".printf (accounts.formal.instance, account.id);
+        var url = "%s/api/v1/follow_requests/%s/authorize".printf (accounts.formal.instance, account.id);
         var msg = new Soup.Message ("POST", url);
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg);
@@ -85,7 +85,7 @@ public class Olifant.API.Notification {
     }
 
     public Soup.Message reject_follow_request () {
-        var url = "%s/api/v1/follow_requests/%lld/reject".printf (accounts.formal.instance, account.id);
+        var url = "%s/api/v1/follow_requests/%s/reject".printf (accounts.formal.instance, account.id);
         var msg = new Soup.Message ("POST", url);
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg);

--- a/src/API/Relationship.vala
+++ b/src/API/Relationship.vala
@@ -2,7 +2,7 @@ using GLib;
 
 public class Olifant.API.Relationship : Object {
 
-    public int64 id;
+    public string id;
     public bool following;
     public bool followed_by;
     public bool blocking;
@@ -11,12 +11,12 @@ public class Olifant.API.Relationship : Object {
     public bool requested;
     public bool domain_blocking;
 
-    public Relationship (int64 _id) {
+    public Relationship (string _id) {
         id = _id;
     }
 
     public static Relationship parse (Json.Object obj) {
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var relationship = new Relationship (id);
         relationship.following = obj.get_boolean_member ("following");
         relationship.followed_by = obj.get_boolean_member ("followed_by");

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -3,7 +3,7 @@ public class Olifant.API.Status {
     public signal void updated ();
 
     public API.Account account;
-    public int64 id;
+    public string id;
     public string uri;
     public string url;
     public string? spoiler_text;
@@ -22,7 +22,7 @@ public class Olifant.API.Status {
     public API.Mention[]? mentions;
     public API.Attachment[]? attachments;
 
-    public Status (int64 _id) {
+    public Status (string _id) {
         id = _id;
     }
 
@@ -31,7 +31,7 @@ public class Olifant.API.Status {
     }
 
     public static Status parse (Json.Object obj) {
-        var id = int64.parse (obj.get_string_member ("id"));
+        var id = obj.get_string_member ("id");
         var status = new Status (id);
 
         status.account = Account.parse (obj.get_object_member ("account"));
@@ -169,7 +169,7 @@ public class Olifant.API.Status {
 
     public void set_reblogged (bool rebl, Network.ErrorCallback? err = network.on_error) {
         var action = rebl ? "reblog" : "unreblog";
-        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%lld/%s".printf (accounts.formal.instance, id, action));
+        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%s/%s".printf (accounts.formal.instance, id, action));
         msg.priority = Soup.MessagePriority.HIGH;
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, message) => {
@@ -182,7 +182,7 @@ public class Olifant.API.Status {
 
     public void set_favorited (bool fav, Network.ErrorCallback? err = network.on_error) {
         var action = fav ? "favourite" : "unfavourite";
-        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%lld/%s".printf (accounts.formal.instance, id, action));
+        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%s/%s".printf (accounts.formal.instance, id, action));
         msg.priority = Soup.MessagePriority.HIGH;
         network.inject (msg, Network.INJECT_TOKEN);
             network.queue (msg, (sess, message) => {
@@ -195,7 +195,7 @@ public class Olifant.API.Status {
 
     public void set_muted (bool mute, Network.ErrorCallback? err = network.on_error) {
         var action = mute ? "mute" : "unmute";
-        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%lld/%s".printf (accounts.formal.instance, id, action));
+        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%s/%s".printf (accounts.formal.instance, id, action));
         msg.priority = Soup.MessagePriority.HIGH;
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, message) => {
@@ -208,7 +208,7 @@ public class Olifant.API.Status {
 
     public void set_pinned (bool pin, Network.ErrorCallback? err = network.on_error) {
         var action = pin ? "pin" : "unpin";
-        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%lld/%s".printf (accounts.formal.instance, id, action));
+        var msg = new Soup.Message ("POST", "%s/api/v1/statuses/%s/%s".printf (accounts.formal.instance, id, action));
         msg.priority = Soup.MessagePriority.HIGH;
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, message) => {
@@ -220,7 +220,7 @@ public class Olifant.API.Status {
     }
 
     public void poof (Soup.SessionCallback? cb = null, Network.ErrorCallback? err = network.on_error) {
-        var msg = new Soup.Message ("DELETE", "%s/api/v1/statuses/%lld".printf (accounts.formal.instance, id));
+        var msg = new Soup.Message ("DELETE", "%s/api/v1/statuses/%s".printf (accounts.formal.instance, id));
         msg.priority = Soup.MessagePriority.HIGH;
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, message) => {

--- a/src/API/VersionInfo.vala
+++ b/src/API/VersionInfo.vala
@@ -1,0 +1,31 @@
+public class Olifant.API.VersionInfo {
+    public uint major;
+    public uint minor;
+    public uint patch;
+
+    public VersionInfo(uint _major = 0, uint _minor = 0, uint _patch = 0) {
+        major = _major;
+        minor = _minor;
+        patch = _patch;
+    }
+
+    public static VersionInfo parse(string ver) {
+        var info = new VersionInfo ();
+        var parts = ver.split(".");
+
+        if (parts[0] != null)
+            info.major = uint.parse(parts[0]);
+
+        if (parts[1] != null)
+            info.minor = uint.parse(parts[1]);
+
+        if (parts[2] != null) 
+            info.patch = uint.parse(parts[2]);
+
+        return info;
+    } 
+
+    public string show () {
+        return "VersionInfo(major=%u, minor=%u, patch=%u)".printf (major, minor, patch);
+    }
+}

--- a/src/Accounts.vala
+++ b/src/Accounts.vala
@@ -9,9 +9,12 @@ public class Olifant.Accounts : Object {
     public signal void updated (GenericArray<InstanceAccount> accounts);
 
     public GenericArray<InstanceAccount> saved_accounts = new GenericArray<InstanceAccount> ();
-    public InstanceAccount? formal {get; set;}
-    public API.Account? current {get; set;}
-    public API.Instance? currentInstance {get; set;}
+    public GenericArray<API.Instance?> instance_data = new GenericArray<API.Instance> ();
+    public InstanceAccount? formal {get; private set;}
+    public API.Account? current {get; private set;}
+    public API.Instance? currentInstance {
+        get { return instance_data.@get (settings.current_account); }
+    }
 
     public Accounts () {
         dir_path = "%s/%s".printf (GLib.Environment.get_user_config_dir (), app.application_id);
@@ -22,6 +25,7 @@ public class Olifant.Accounts : Object {
         info ("Switching to #%i", id);
         settings.current_account = id;
         formal = saved_accounts.@get (id);
+
         var msg = new Soup.Message ("GET", "%s/api/v1/accounts/verify_credentials".printf (accounts.formal.instance));
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, mess) => {
@@ -31,20 +35,13 @@ public class Olifant.Accounts : Object {
                 updated (saved_accounts);
             },
             network.on_show_error);
-
-        info ("Getting information from %s", accounts.formal.instance);
-        msg = new Soup.Message ("GET", "%s/api/v1/instance".printf (accounts.formal.instance));
-        network.queue (msg, (sess, mess) => {
-                var root = network.parse (mess);
-                currentInstance = API.Instance.parse (root);
-            },
-            network.on_show_error);
     }
 
     public void add (InstanceAccount account) {
         info ("Adding account for %s at %s", account.username, account.instance);
         saved_accounts.add (account);
         save ();
+        load_instances_info (saved_accounts);
         updated (saved_accounts);
         switch_account (saved_accounts.length - 1);
         account.start_notificator ();
@@ -66,6 +63,7 @@ public class Olifant.Accounts : Object {
             switch_account (id);
         }
         save ();
+        load_instances_info (saved_accounts);
         updated (saved_accounts);
 
         if (is_empty ()) {
@@ -86,6 +84,32 @@ public class Olifant.Accounts : Object {
             Dialogs.NewAccount.open ();
         else
             switch_account (settings.current_account);
+    }
+
+    protected void load_instances_info (GenericArray<InstanceAccount> saved_accounts) {
+        info ("Reloading instances info");
+        instance_data = new GenericArray<API.Instance?> ();
+        for (var curId = 0; curId < saved_accounts.length; curId++) {
+            // Kind of a dirty hack, if no value added, but if array size 
+            // specified in constructor, value gets deconstructed as long
+            // as it leaves load_single_instance function
+            instance_data.add (null);
+            load_single_instance (curId++);
+        }
+    }
+
+    protected void load_single_instance(int current_id) {
+        var cur_acc = this.saved_accounts.@get (current_id);
+        var cur_instance = cur_acc.instance;
+        info ("Getting information for %s for #%i", cur_instance, current_id);
+        var instMsg = new Soup.Message ("GET", "%s/api/v1/instance".printf (cur_instance));
+        network.queue (instMsg, (sess, mess) => {
+                var root = network.parse (mess);
+                var instance = API.Instance.parse (root);
+                instance_data.@set (current_id, instance);
+                info ("DONE: Getting information of %s for #%i", cur_instance, current_id);
+            },
+            network.on_show_error);
     }
 
     public void save (bool overwrite = true) {
@@ -143,6 +167,7 @@ public class Olifant.Accounts : Object {
                 }
             });
             debug ("Loaded %i saved accounts", saved_accounts.length);
+            load_instances_info (saved_accounts);
             updated (saved_accounts);
         }
         catch (GLib.Error e){

--- a/src/InstanceAccount.vala
+++ b/src/InstanceAccount.vala
@@ -10,7 +10,7 @@ public class Olifant.InstanceAccount : Object {
     public string token {get; set;}
     public int64? status_char_limit {get; set;}
 
-    public int64 last_seen_notification {get; set; default = 0;}
+    public string last_seen_notification {get; set; default = "";}
     public bool has_unread_notifications {get; set; default = false;}
     public ArrayList<API.Notification> cached_notifications {get; set;}
 
@@ -67,7 +67,7 @@ public class Olifant.InstanceAccount : Object {
         builder.set_member_name ("token");
         builder.add_string_value (token);
         builder.set_member_name ("last_seen_notification");
-        builder.add_int_value (last_seen_notification);
+        builder.add_string_value (last_seen_notification);
         builder.set_member_name ("has_unread_notifications");
         builder.add_boolean_value (has_unread_notifications);
         if (status_char_limit != null) {
@@ -96,7 +96,7 @@ public class Olifant.InstanceAccount : Object {
         acc.client_id = obj.get_string_member ("id");
         acc.client_secret = obj.get_string_member ("secret");
         acc.token = obj.get_string_member ("token");
-        acc.last_seen_notification = obj.get_int_member ("last_seen_notification");
+        acc.last_seen_notification = obj.get_string_member ("last_seen_notification");
         acc.has_unread_notifications = obj.get_boolean_member ("has_unread_notifications");
         if (obj.has_member("status_char_limit")) {
             acc.status_char_limit = obj.get_int_member ("status_char_limit");
@@ -136,7 +136,7 @@ public class Olifant.InstanceAccount : Object {
         }
     }
 
-    private void status_removed (int64 id) {
+    private void status_removed (string id) {
         if (is_current ())
             network.status_removed (id);
     }
@@ -148,7 +148,7 @@ public class Olifant.InstanceAccount : Object {
         watchlist.users.@foreach (item => {
         	var acct = status.account.acct;
             if (item == acct || item == "@" + acct) {
-                var obj = new API.Notification (-1);
+                var obj = new API.Notification ("");
                 obj.type = API.NotificationType.WATCHLIST;
                 obj.account = status.account;
                 obj.status = status;

--- a/src/Network.vala
+++ b/src/Network.vala
@@ -10,7 +10,7 @@ public class Olifant.Network : GLib.Object {
     public signal void started ();
     public signal void finished ();
     public signal void notification (API.Notification notification);
-    public signal void status_removed (int64 id);
+    public signal void status_removed (string id);
 
 	public delegate void ErrorCallback (int32 code, string reason);
 	public delegate void SuccessCallback (Session session, Message msg) throws GLib.Error;

--- a/src/Notificator.vala
+++ b/src/Notificator.vala
@@ -10,7 +10,7 @@ public class Olifant.Notificator : GLib.Object {
 
     public signal void notification (API.Notification notification);
     public signal void status_added (API.Status status);
-    public signal void status_removed (int64 id);
+    public signal void status_removed (string id);
 
     public Notificator (Soup.Message _msg){
         msg = _msg;
@@ -98,7 +98,7 @@ public class Olifant.Notificator : GLib.Object {
                 if (!settings.live_updates)
                     return;
 
-                var id = int64.parse (root.get_string_member("payload"));
+                var id = root.get_string_member("payload");
                 status_removed (id);
                 break;
             case "notification":

--- a/src/Views/ExpandedStatus.vala
+++ b/src/Views/ExpandedStatus.vala
@@ -46,7 +46,7 @@ public class Olifant.Views.ExpandedStatus : Views.Abstract {
     }
 
     public Soup.Message request (){
-        var url = "%s/api/v1/statuses/%lld/context".printf (accounts.formal.instance, root_status.id);
+        var url = "%s/api/v1/statuses/%s/context".printf (accounts.formal.instance, root_status.id);
         var msg = new Soup.Message ("GET", url);
         network.inject (msg, Network.INJECT_TOKEN);
         network.queue (msg, (sess, mess) => {

--- a/src/Views/Notifications.vala
+++ b/src/Views/Notifications.vala
@@ -3,7 +3,7 @@ using Gdk;
 
 public class Olifant.Views.Notifications : Views.Abstract {
 
-    private int64 last_id = 0;
+    private string last_id = "";
     private bool force_dot = false;
 
     public Notifications () {

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -215,7 +215,7 @@ public class Olifant.Views.Profile : Views.Timeline {
         if (page_next != null)
             return page_next;
 
-        var url = "%s/api/v1/accounts/%lld/statuses?limit=%i".printf (accounts.formal.instance, account.id, this.limit);
+        var url = "%s/api/v1/accounts/%s/statuses?limit=%i".printf (accounts.formal.instance, account.id, this.limit);
         return url;
     }
 
@@ -237,8 +237,8 @@ public class Olifant.Views.Profile : Views.Timeline {
             return null;
     }
 
-    public static void open_from_id (int64 id){
-        var url = "%s/api/v1/accounts/%lld".printf (accounts.formal.instance, id);
+    public static void open_from_id (string id){
+        var url = "%s/api/v1/accounts/%s".printf (accounts.formal.instance, id);
         var msg = new Soup.Message ("GET", url);
         msg.priority = Soup.MessagePriority.HIGH;
         network.queue (msg, (sess, mess) => {

--- a/src/Views/Timeline.vala
+++ b/src/Views/Timeline.vala
@@ -103,7 +103,7 @@ public class Olifant.Views.Timeline : Views.Abstract {
             return page_next;
 
         var url="";
-        if(accounts.currentInstance.version.ascii_casecmp ("3.0.0")>=0 && this.timeline=="direct"){
+        if (accounts.currentInstance.is_mastodon_v3 () && this.timeline == "direct") {
             url = "%s/api/v1/notifications?exclude_types[]=favourite&exclude_types[]=reblog".printf (accounts.formal.instance);
             url += "&exclude_types[]=follow&exclude_types[]=poll&limit=%i".printf (this.limit);
             url += this.pars;
@@ -120,9 +120,9 @@ public class Olifant.Views.Timeline : Views.Abstract {
         if (object == null) {
             return;
         }
-        if(accounts.currentInstance.version.ascii_casecmp ("3.0.0")>=0 && this.timeline=="direct"){
+        if (accounts.currentInstance.is_mastodon_v3 () && this.timeline == "direct"){
             var nots = API.Notification.parse(object);
-            if (nots.status.visibility==API.StatusVisibility.DIRECT){
+            if (nots.status != null && nots.status.visibility==API.StatusVisibility.DIRECT) {
                 append(nots.status);
             }
         } else{

--- a/src/Watchlist.vala
+++ b/src/Watchlist.vala
@@ -80,7 +80,7 @@ public class Olifant.Watchlist : Object {
     }
 
     private void on_status_added (API.Status status) {
-        var obj = new API.Notification (-1);
+        var obj = new API.Notification ("");
         obj.type = API.NotificationType.WATCHLIST;
         obj.account = status.account;
         obj.status = status;

--- a/src/Widgets/Account.vala
+++ b/src/Widgets/Account.vala
@@ -3,7 +3,7 @@ using Gdk;
 public class Olifant.Widgets.Account : Widgets.Status {
 
     public Account (API.Account account) {
-        var status = new API.Status (-1);
+        var status = new API.Status ("");
         status.account = account;
         status.url = account.url;
         status.content = "<a href=\"%s\">@%s</a>".printf (account.url, account.acct);

--- a/src/Widgets/AttachmentGrid.vala
+++ b/src/Widgets/AttachmentGrid.vala
@@ -83,7 +83,7 @@ public class Olifant.Widgets.AttachmentGrid : Grid {
         get_children ().@foreach (w => {
             var widget = (ImageAttachment) w;
             if (widget.attachment != null)
-                str += "&media_ids[]=%lld".printf (widget.attachment.id);
+                str += "&media_ids[]=%s".printf (widget.attachment.id);
         });
         return str;
     }

--- a/src/Widgets/ImageAttachment.vala
+++ b/src/Widgets/ImageAttachment.vala
@@ -63,7 +63,7 @@ public class Olifant.Widgets.ImageAttachment : DrawingArea {
                 editable = true;
                 invalidate ();
                 network.load_pixbuf (attachment.preview_url, on_ready);
-                info ("Uploaded media: %lld", attachment.id);
+                info ("Uploaded media: %s", attachment.id);
             });
         }
         catch (Error e) {

--- a/src/Widgets/Notification.vala
+++ b/src/Widgets/Notification.vala
@@ -80,7 +80,7 @@ public class Olifant.Widgets.Notification : Grid {
         }
     }
 
-    private void on_status_removed (int64 id) {
+    private void on_status_removed (string id) {
         if (id == notification.status.id) {
             if (notification.type == API.NotificationType.WATCHLIST)
                 notification.dismiss ();

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -58,7 +58,7 @@ public class Olifant.Widgets.RichLabel : Label {
         if ("@" in url || "tags" in url) {
             var query = Soup.URI.encode (url, null);
             var msg_url="";
-            if(accounts.currentInstance.version.ascii_casecmp ("3.0.0")>=0)
+            if (accounts.currentInstance.is_mastodon_v3 ())
                 msg_url = "%s/api/v2/search?q=%s&resolve=true".printf (accounts.formal.instance, query);
             else
                 msg_url = "%s/api/v1/search?q=%s&resolve=true".printf (accounts.formal.instance, query);


### PR DESCRIPTION
This improves identifies compatibility with mastodon itself, because, as it was noted in #33, it is recommended to use string identifiers.

This closes #33